### PR TITLE
feat: upgrade to maven-skin-tools 1.6.00 with improved AI indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
 		<!-- UTF-8 -->
 		<project.reporting.outputEncoding>${project.build.encoding}</project.reporting.outputEncoding>
 
+		<!-- maven-skin-tools version (used in docs and integration tests) -->
+		<skinToolsVersion>1.6.00</skinToolsVersion>
+
 		<!-- Reproducible Build -->
 		<!-- See https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
 		<project.build.outputTimestamp>2026-01-27T13:50:50Z</project.build.outputTimestamp>
@@ -96,7 +99,7 @@
 					<dependency>
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
-						<version>1.5.00</version>
+						<version>${skinToolsVersion}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -239,7 +242,7 @@
 					<postBuildHookScript>verify</postBuildHookScript>
 					<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
 					<extraArtifacts>
-						<extraArtifact>org.sentrysoftware.maven:maven-skin-tools:1.5.00</extraArtifact>
+						<extraArtifact>org.sentrysoftware.maven:maven-skin-tools:${skinToolsVersion}</extraArtifact>
 					</extraArtifacts>
 					<settingsFile>src/it/settings.xml</settingsFile>
 					<goals>

--- a/src/it/studio-km/pom.xml
+++ b/src/it/studio-km/pom.xml
@@ -66,7 +66,7 @@
 					<dependency>
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
-						<version>1.5.00</version>
+						<version>@skinToolsVersion@</version>
 					</dependency>
 				</dependencies>
 

--- a/src/it/studio-km/verify.groovy
+++ b/src/it/studio-km/verify.groovy
@@ -18,7 +18,7 @@ assert result.contains('<meta name="author" content="The &quot;Proud&quot; Peopl
 assert result.contains('<meta property="article:published_time" content="1980-05-22') : "Document's published time is set correctly"
 assert result.contains('<meta property="article:modified_time" content="1980-05-22') : "Document's modified time is set correctly"
 assert result.contains('<link rel="canonical" href="https://the.org/docs/events.html">') : "Document's canonical link is set according to project's URL"
-assert result.contains('<link rel="alternate" type="text/markdown" href="events.md">') : "Document's alternate link is set according to project's URL"
+assert result.contains('<link rel="alternate" type="text/markdown" href="events.html.md">') : "Document's alternate link must use .html.md extension (per llmstxt.org convention)"
 assert result.contains("<b>skin-test</b> allows you") : "pom.xml properties must be replaced with their values"
 
 // Links, breadcrumbs, additionalLinks, and social networks
@@ -92,23 +92,24 @@ assert result.contains('<a href="https://banner.right">Banner Right</a></li>') :
 assert result.contains("images/logo.png") : "bannerRight.src must be included"
 assert result.contains('href="https://banner.right"') : "bannerRight.href must be included"
 
-// Verify that the corresponding .md files are generated
-def mdFile = new File(basedir, "target/site/extend-summary.md")
-assert mdFile.isFile() : "Markdown version of the HTML files must have been generated"
+// Verify that the corresponding .html.md files are generated (using .html.md extension per llmstxt.org convention)
+def mdFile = new File(basedir, "target/site/extend-summary.html.md")
+assert mdFile.isFile() : "Markdown version of the HTML files must have been generated with .html.md extension"
 def mdContent = mdFile.text
 assert mdContent.contains('description: skin-test can be extended') : "In generated Markdown, Frontmatter header must be set according to source's metadata"
 assert mdContent.contains('date_published: 1980-05-22') : "In generated Markdown, Frontmatter published date must be set correctly"
 assert mdContent.contains('date_modified: 1980-05-22') : "In generated Markdown, Frontmatter modified date must be set correctly"
 assert mdContent.contains('# Extending skin-test') : "In generated Markdown, content must be present"
 
-// Verify that the llms.txt file is generated
+// Verify that the llms.txt file is generated with absolute URLs and multi-line blockquote format
 def llmsFile = new File(basedir, "target/site/llms.txt")
 assert llmsFile.isFile() : "llms.txt file must have been generated"
 def llmsContent = llmsFile.text
 assert llmsContent.contains('# skin-test Extended') : "In llms.txt, title must be present"
-assert llmsContent.contains('> A full documentation project (copied from Monitoring Studio)') : "In llms.txt, description must be present"
+assert llmsContent.contains('> A full documentation project (copied from Monitoring Studio)') : "In llms.txt, description must be present (multi-line blockquote format)"
 assert llmsContent.contains('## Getting Started') : "In llms.txt, menu section must be present"
-assert llmsContent.contains('- [Operating the Console](console.md)') : "In llms.txt, menu items must be present"
+assert llmsContent.contains('- [Operating the Console](https://the.org/docs/console.html.md)') : "In llms.txt, menu items must use absolute URLs with .html.md extension"
+assert llmsContent.contains('https://the.org/docs/') : "In llms.txt, URLs must be absolute when project URL is configured"
 
 // Verify documents in a subdir
 def agentFile = new File(basedir, "target/site/subdir/agent.html")

--- a/src/main/webapp/site.vm
+++ b/src/main/webapp/site.vm
@@ -49,7 +49,7 @@ $headElement.html()
 ## AI Indexing: generate Markdown files for AI platforms and inserts a <link rel="alternate" /> in the head
 	$aiIndexTool.convertToMarkdown(${project.reporting.outputDirectory}, $currentFileName, $headElement, $bodyElement, $publishDate, $project.url)#*
 *##set($menuSection = "#getMenuSection()")#*
-*##call($aiIndexTool.updateLlmsTxt("${project.reporting.outputDirectory}/llms.txt", $currentFileName, $shortTitle, $decoration.name, $project.description, $menuSection))#*
+*##call($aiIndexTool.updateLlmsTxt("${project.reporting.outputDirectory}/llms.txt", $currentFileName, $shortTitle, $decoration.name, $project.description, $menuSection, $project.url))#*
 *#
 	<!-- build:css css/main-combined.css -->
 	<link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css">

--- a/src/site/markdown/ai-indexing.md
+++ b/src/site/markdown/ai-indexing.md
@@ -11,32 +11,40 @@ ${project.name} automatically generates files to help AI platforms (ChatGPT, Git
 
 During build, the skin creates:
 
-1. **`llms.txt`** - Structured index following the [llms.txt convention](https://llmstxt.org/)
-2. **`.md` files** - Markdown version of each HTML page
-3. **`<link>` tags** - References to Markdown versions in HTML
+1. **`llms.txt`** - Structured index following the [llmstxt.org](https://llmstxt.org/) proposal format
+2. **`.html.md` files** - Markdown version of each HTML page (using the `.html.md` extension convention per llmstxt.org)
+3. **`<link>` tags** - References to Markdown versions in HTML headers
 
 ### llms.txt Format
+
+The `llms.txt` file follows the [llmstxt.org proposal](https://llmstxt.org/) and includes:
 
 ```markdown
 # My Project
 
 > A powerful library for doing amazing things
+> that spans multiple lines when needed.
 
 ## Getting Started
 
-- [Installation](installation.html)
-- [Quick Start](quickstart.html)
+- [Installation](https://example.com/docs/installation.html.md)
+- [Quick Start](https://example.com/docs/quickstart.html.md)
 
 ## User Guide
 
-- [Configuration](configuration.html)
+- [Configuration](https://example.com/docs/configuration.html.md)
 ```
 
-Sections are generated from your `site.xml` menu structure.
+Key features:
+
+- **Absolute URLs**: When `<url>` is defined in `pom.xml`, links are absolute (e.g., `https://example.com/docs/page.html.md`)
+- **Multi-line blockquotes**: Project descriptions are properly formatted with `> ` prefix on each line
+- **`.html.md` extension**: URLs use the `.html.md` convention (appending `.md` to the original HTML URL)
+- **Menu sections**: Sections are generated from your `site.xml` menu structure
 
 ### Markdown Files
 
-Each HTML page gets a corresponding `.md` file with YAML front matter:
+Each HTML page gets a corresponding `.html.md` file with YAML front matter:
 
 ```yaml
 ---
@@ -47,13 +55,17 @@ canonical_url: https://example.com/docs/install.html
 ---
 ```
 
+The `.html.md` extension convention (appending `.md` to the original URL) allows AI platforms to easily determine the Markdown equivalent of any HTML page.
+
 ### Link Tags
 
 HTML pages include a link to their Markdown version:
 
 ```html
-<link rel="alternate" type="text/markdown" href="page.md"/>
+<link rel="alternate" type="text/markdown" href="page.html.md"/>
 ```
+
+This tells AI crawlers where to find the Markdown version of the current page.
 
 ## SEO Features
 
@@ -75,7 +87,9 @@ For best results, define `<url>` in your `pom.xml`:
 </project>
 ```
 
-2. Define `<description>` in your `pom.xml`:
+When `<url>` is defined, links in `llms.txt` become absolute URLs, making them easier for AI platforms to index regardless of context. If `<url>` is not defined, links remain relative.
+
+Also define `<description>` in your `pom.xml`:
 
 ```xml
 <project>

--- a/src/site/markdown/start.md
+++ b/src/site/markdown/start.md
@@ -46,7 +46,7 @@ Add the Maven Site Plugin with the required dependency:
         <dependency>
           <groupId>org.sentrysoftware.maven</groupId>
           <artifactId>maven-skin-tools</artifactId>
-          <version>1.5.00</version>
+          <version>${skinToolsVersion}</version>
         </dependency>
       </dependencies>
     </plugin>


### PR DESCRIPTION
## Summary

Upgrade to maven-skin-tools 1.6.00 to leverage improved AI/LLM indexing features that follow the [llmstxt.org](https://llmstxt.org/) proposal more closely.

## Changes

### Dependency Management
- **New `skinToolsVersion` property** (`1.6.00`) in `pom.xml` to centralize version management
- Updated all references to use this property (main pom.xml, integration tests, documentation)
- Fixes an issue where the invoker plugin was still referencing 1.5.00

### AI Indexing Improvements
- **Velocity template**: Updated `updateLlmsTxt()` call to use the new 7-parameter version with `$project.url` for absolute URLs
- **`.html.md` extension**: Markdown files now use `.html.md` instead of `.md` (per llmstxt.org convention)
- **Absolute URLs**: Links in `llms.txt` are now absolute when `<url>` is defined in `pom.xml`
- **Multi-line blockquotes**: Project descriptions properly formatted with `> ` on each line

### Updated Files
| File | Change |
|------|--------|
| `pom.xml` | Added `skinToolsVersion` property, updated dependency references |
| `src/it/studio-km/pom.xml` | Use `@skinToolsVersion@` interpolation |
| `src/main/webapp/site.vm` | Updated `updateLlmsTxt()` to 7-parameter version |
| `src/it/studio-km/verify.groovy` | Updated tests for `.html.md` and absolute URLs |
| `src/site/markdown/ai-indexing.md` | Updated documentation with new features |
| `src/site/markdown/start.md` | Use `${skinToolsVersion}` property |

## Testing

- [x] `mvn verify` passes
- [x] Integration tests updated to verify:
  - `.html.md` file extension for Markdown files
  - `<link rel="alternate">` points to `.html.md` files
  - `llms.txt` contains absolute URLs (e.g., `https://the.org/docs/console.html.md`)

## Related

- Depends on [maven-skin-tools 1.6.00](https://github.com/sentrysoftware/maven-skin-tools)