### PR TITLE
fix: improve schema.org metadata with ISO dates and author field

### DIFF
--- a/src/it/studio-km/verify.groovy
+++ b/src/it/studio-km/verify.groovy
@@ -80,6 +80,12 @@ assert result =~ /Copyright.*1975.*1980/ : "inceptionYear must be displayed in t
 assert result =~ /The Organization/ : '${project.organization.name} must be displayed in the footer'
 assert result =~ /https:\/\/the\.org/ : '${project.organization.url} must be displayed in the footer'
 
+// schema.org JSON-LD metadata
+assert result =~ /"datePublished":\s*"1980-05-22T/ : "schema.org datePublished must be in ISO format with time"
+assert result =~ /"dateModified":\s*"1980-05-22T/ : "schema.org dateModified must be in ISO format with time"
+assert result =~ /"@type":\s*"Person"/ : "schema.org author must use Person type"
+assert result =~ /"@type":\s*"Person"[\s\S]*?"name":\s*"The / : "schema.org author must have a name field"
+
 // Google Analytics
 assert result.contains("(window,document,'script','dataLayer','MY_GOOGLE_ID')") : "Specific googleAnalyticsAccountId must be inserted"
 

--- a/src/main/webapp/site.vm
+++ b/src/main/webapp/site.vm
@@ -77,10 +77,21 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	"@context": "https://schema.org",
 	"@type": "TechArticle",
 	"headline": "$esc.java($shortTitle)",
-	"datePublished": "$date.format('YYYY-MM-dd', $publishDate)",
-	"dateModified": "$date.format('YYYY-MM-dd', $publishDate)",
+	"datePublished": "$date.format('iso', $publishDate)",
+	"dateModified": "$date.format('iso', $publishDate)",
 #if ($project.url)
-	"mainEntityOfPage": "$esc.java($PathTool.calculateLink($currentFileName, $project.url))"
+	"mainEntityOfPage": "$esc.java($PathTool.calculateLink($currentFileName, $project.url))",
+#end
+#if (!$authors.isEmpty())
+	"author": [
+#foreach ($author in $authors)
+		{
+			"@type": "Person",
+			"name": "$esc.java($author)"
+		}#if ($foreach.hasNext),#end
+
+#end
+	]
 #end
 }
 </script>


### PR DESCRIPTION
## Summary

Fixes schema.org JSON-LD metadata validation issues reported by Google's Rich Results Test.

## Changes

### Fixed datetime format
- Changed `datePublished` and `dateModified` from `YYYY-MM-dd` format to ISO 8601 format with timezone
- Now uses the same `'iso'` format already used elsewhere in the template (e.g., `article:published_time` meta tags)

### Added author field
- When document authors are available, the schema.org metadata now includes an `author` array with properly typed `Person` entries
- Author names are properly JSON-escaped

### Before
```json
{
  "@context": "https://schema.org",
  "@type": "TechArticle",
  "headline": "Page Title",
  "datePublished": "2026-01-28",
  "dateModified": "2026-01-28"
}
```

### After
```json
{
  "@context": "https://schema.org",
  "@type": "TechArticle",
  "headline": "Page Title",
  "datePublished": "2026-01-28T00:00:00Z",
  "dateModified": "2026-01-28T00:00:00Z",
  "author": [
    {
      "@type": "Person",
      "name": "John Doe"
    }
  ]
}
```

## Addresses

Google Rich Results Test feedback:
- ~~Invalid datetime value for "datePublished"~~ ✅
- ~~Datetime property "datePublished" is missing a timezone~~ ✅
- ~~Invalid datetime value for "dateModified"~~ ✅
- ~~Datetime property "dateModified" is missing a timezone~~ ✅
- ~~Missing field "author"~~ ✅ (when authors are specified)
- Missing field "image" - Not addressed (no suitable image source available)

## Testing

- Added integration tests in `verify.groovy` to validate schema.org output
- `mvn verify` passes